### PR TITLE
Clear monitoring list when paused

### DIFF
--- a/NemosMiner.ps1
+++ b/NemosMiner.ps1
@@ -119,6 +119,7 @@ Function Global:TimerUITick {
         If ($Variables.Paused) {
             $EarningsDGV.DataSource = [System.Collections.ArrayList]@()
             $RunningMinersDGV.DataSource = [System.Collections.ArrayList]@()
+            $WorkersDGV.DataSource = [System.Collections.ArrayList]@()
             $LabelBTCD.ForeColor = "Red"
             $TimerUI.Stop
         }


### PR DESCRIPTION
Since the UI no longer updates when paused, having the workers still listed on the monitoring tab but not updating can cause confusion.  Clears the list when paused.